### PR TITLE
Fix readthedocs build re: packaging modernization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ NEMO Command Processor
 .. image:: https://img.shields.io/badge/license-Apache%202-cb2533.svg
     :target: https://www.apache.org/licenses/LICENSE-2.0
     :alt: Licensed under the Apache License, Version 2.0
-.. image:: https://img.shields.io/badge/Python-3.10 | 3.11-blue?logo=python&label=Python&logoColor=gold
+.. image:: https://img.shields.io/badge/Python-3.10%20%7C%203.11-blue?logo=python&label=Python&logoColor=gold
     :target: https://docs.python.org/3.11/
     :alt: Python Version
 .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -25,7 +25,7 @@
 .. image:: https://img.shields.io/badge/license-Apache%202-cb2533.svg
     :target: https://www.apache.org/licenses/LICENSE-2.0
     :alt: Licensed under the Apache License, Version 2.0
-.. image:: https://img.shields.io/badge/Python-3.10 | 3.11-blue?logo=python&label=Python&logoColor=gold
+.. image:: https://img.shields.io/badge/Python-3.10%20%7C%203.11-blue?logo=python&label=Python&logoColor=gold
     :target: https://docs.python.org/3.11/
     :alt: Python Version
 .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github
@@ -65,7 +65,7 @@
 Python Versions
 ===============
 
-.. image:: https://img.shields.io/badge/Python-3.10 | 3.11-blue?logo=python&label=Python&logoColor=gold
+.. image:: https://img.shields.io/badge/Python-3.10%20%7C%203.11-blue?logo=python&label=Python&logoColor=gold
     :target: https://docs.python.org/3.11/
     :alt: Python Version
 

--- a/envs/environment-rtd.yaml
+++ b/envs/environment-rtd.yaml
@@ -7,6 +7,7 @@ channels:
   - nodefaults
 
 dependencies:
+  - pip
   - python=3.11
 
   # RTD packages
@@ -15,3 +16,7 @@ dependencies:
   - sphinx
   - sphinx_rtd_theme
   - sphinx-notfound-page
+
+  - pip:
+      # install package so that importlib.metadata functions can work
+      - ../

--- a/envs/environment-test.yaml
+++ b/envs/environment-test.yaml
@@ -34,5 +34,5 @@ dependencies:
     # For unit tests
     - pytest-randomly
 
-    # editable install of NEMO-Cmd package
-    - --editable ../
+    # install NEMO-Cmd package
+    - ../


### PR DESCRIPTION
Install package in readthedocs environment so that `importlib.metadata.version()` works.