### PR TITLE
Add environment-hpc.yaml conda env description

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -5,6 +5,9 @@ Change Log
 v22.2.dev0 (unreleased)
 =======================
 
+* Add :file:`envs/environment-hpc.yaml` to build conda environments on HPC clusters
+  from which the package can be installed using the ``--user`` scheme for installation.
+
 * Modernize packaging:
 
   * Replace :file:`setup.py` and :file:`setup.cfg` with :file:`pyproject.toml`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,8 @@
 :kbd:`NEMO-Cmd` Package Installation
 ************************************
 
-:kbd:`NEMO-Cmd` is a Python package that provides the :program:`nemo` command-line tool for doing various operations associated running with the `NEMO`_ ocean model.
+:kbd:`NEMO-Cmd` is a Python package that provides the :program:`nemo` command-line tool
+for doing various operations associated running with the `NEMO`_ ocean model.
 
 .. _NEMO: https://www.nemo-ocean.eu/
 
@@ -40,43 +41,22 @@ These instructions assume that:
   .. _Miniforge: https://github.com/conda-forge/miniforge
   .. _Miniconda3: https://docs.conda.io/en/latest/miniconda.html
 
-To install the :kbd:`NEMO-Cmd` package in your :kbd:`base` Conda environment use:
+To install the :kbd:`NEMO-Cmd` package so that the :command:`nemo` command is available
+in your :file:`$HOME/.local/bin/ directory:
 
 .. code-block:: bash
 
     $ cd NEMO-Cmd
-    $ python3 -m pip install --user --editable .
+    $ conda env create -f envs/environment-hpc.yaml
+    $ conda activate nemo-cmd
+    (nemo-cmd)$ python3 -m pip install --user --editable .
 
-The :kbd:`--editable` option in the :command:`pip install` commands installs the packages via symlinks so that :program:`nemo` will be automatically updated as the repo evolves.
+The :kbd:`--editable` option in the :command:`pip install` commands installs the package
+in a way that it can be updated when new features are pushed to GitHub by simply doing a
+:command:`git pull` in the :file:`NEMO-Cmd/` directory.
 
 The :kbd:`Nemo-Cmd` package can also be installed in an isolated :program:`conda` environment.
 The common use case for doing so it development,
 testing,
 and documentation of the package;
 please see the :ref:`NEMO-CmdPackageDevelopment` section for details.
-
-
-.. _nemoTabCompletion:
-
-:kbd:`<TAB>` Completion
-=======================
-
-.. note::
-
-    :kbd:`<TAB>` completion is only available in recent versions of :command:`bash`.
-    The instructions below are only useful if you are working on Ubuntu 14.04 or later.
-
-The :program:`nemo` command line interface includes a sub-command that enables it to hook into the :program:`bash` :kbd:`<TAB>` completion machinery.
-(:kbd:`<TAB>` completion or `command-line completion`_ is a shell feature whereby partially typed commands are filled out by the shell when the user presses the :kbd:`<TAB>` key.)
-The :command:`nemo complete` command prints a blob of :program:`bash` code that does the job,
-so,
-capturing that code and executing it with the :command:`eval` command will enable completion for :program:`nemo` in your current shell session.
-You can do that with the compound command:
-
-.. code-block:: bash
-
-    eval "$(nemo complete)"
-
-Including that line in your :file:`~/.bashrc` file will ensure that completion for :program:`nemo` is available in every shell you launch.
-
-.. _command-line completion: https://en.wikipedia.org/wiki/Command-line_completion

--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -1,16 +1,16 @@
 # conda environment description file for NEMO-Cmd package
 # development environment
 #
-# Create a conda environment in which the `nemo` command can be run
+# Create a conda environment in which the `nemo` command is installed in editable mode
 # with:
 #
-#   $ conda env create -f NEMO-Cmd/envs/environment.yaml
-#   $ source activate nemo-cmd
+#   $ conda env create -f NEMO-Cmd/envs/environment-dev.yaml
+#   $ conda activate nemo-cmd
 #
-# The environment will also include all the tools used to develop,
+# The environment includes all the tools used to develop,
 # test, and document the NEMO-Cmd package.
 #
-# See the requirements.txt file for an exhaustive list of all the
+# See the envs/requirements.txt file for an exhaustive list of all the
 # packages installed in the environment and their versions used in
 # recent development.
 

--- a/envs/environment-hpc.yaml
+++ b/envs/environment-hpc.yaml
@@ -1,0 +1,26 @@
+# conda environment description file for NEMO-Cmd package installation on HPC clusters
+#
+# Create a conda environment from and install the `nemo` command with:
+#
+#   $ conda env create -f NEMO-Cmd/envs/environment-hpc.yaml
+#   $ conda activate nemo-cmd
+#   (nemo-cmd)$ python3 -m pip install --user --editable NEMO-Cmd
+
+name: nemo-cmd
+
+channels:
+  - conda-forge
+  - nodefaults
+
+dependencies:
+  - arrow
+  - attrs
+  - cliff
+  - f90nml
+  - gitpython
+  - pip
+  - python=3.11
+  - pyyaml
+
+  - pip:
+    - python-hglib


### PR DESCRIPTION
* Buff comments in environment-dev.yaml file
* Update installation docs re: --user scheme installation from HPC env
* Delete tab-completion setup from installation docs because nobody ever uses it