### PR TITLE
Change project badges layout in dev docs & README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,42 +2,50 @@
 NEMO Command Processor
 **********************
 
-.. image:: https://img.shields.io/badge/license-Apache%202-cb2533.svg
-    :target: https://www.apache.org/licenses/LICENSE-2.0
-    :alt: Licensed under the Apache License, Version 2.0
-.. image:: https://img.shields.io/badge/Python-3.11%20%7C%203.12-blue?logo=python&label=Python&logoColor=gold
-    :target: https://docs.python.org/3.12/
-    :alt: Python Version
-.. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github
-    :target: https://github.com/SalishSeaCast/NEMO-Cmd
-    :alt: Git on GitHub
-.. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
-    :target: https://github.com/pre-commit/pre-commit
-    :alt: pre-commit
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://black.readthedocs.io/en/stable/
-    :alt: The uncompromising Python code formatter
-.. image:: https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg
-    :alt: Hatch project
-    :target: https://github.com/pypa/hatch
-.. image:: https://readthedocs.org/projects/nemo-cmd/badge/?version=latest
-    :target: https://nemo-cmd.readthedocs.io/en/latest/
-    :alt: Documentation Status
-.. image:: https://github.com/SalishSeaCast/NEMO-Cmd/workflows/sphinx-linkcheck/badge.svg
-    :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:sphinx-linkcheck
-    :alt: Sphinx linkcheck
-.. image:: https://github.com/SalishSeaCast/NEMO-Cmd/workflows/pytest-with-coverage/badge.svg
-    :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:pytest-with-coverage
-    :alt: Pytest with Coverage Status
-.. image:: https://codecov.io/gh/SalishSeaCast/NEMO-Cmd/branch/main/graph/badge.svg
-    :target: https://app.codecov.io/gh/SalishSeaCast/NEMO-Cmd
-    :alt: Codecov Testing Coverage Report
-.. image:: https://github.com/SalishSeaCast/NEMO-Cmd/workflows/CodeQL/badge.svg
-    :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:CodeQL
-    :alt: CodeQL analysis
-.. image:: https://img.shields.io/github/issues/SalishSeaCast/NEMO-Cmd?logo=github
-    :target: https://github.com/SalishSeaCast/NEMO-Cmd/issues
-    :alt: Issue Tracker
++------------------------------+---------------------------------------------------------------------------------------------------------------------+
+|  **Continuous Integration**  |  .. image:: https://github.com/SalishSeaCast/NEMO-Cmd/actions/workflows/pytest-with-coverage.yaml/badge.svg         |
+|                              |       :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:pytest-with-coverage                |
+|                              |       :alt: Pytest with Coverage Status                                                                             |
+|                              |  .. image:: https://codecov.io/gh/SalishSeaCast/NEMO-Cmd/branch/main/graph/badge.svg                                |
+|                              |       :target: https://app.codecov.io/gh/SalishSeaCast/NEMO-Cmd                                                     |
+|                              |       :alt: Codecov Testing Coverage Report                                                                         |
+|                              |  .. image:: https://github.com/SalishSeaCast/NEMO-Cmd/actions/workflows/codeql-analysis.yaml/badge.svg              |
+|                              |      :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:CodeQL                               |
+|                              |      :alt: CodeQL analysis                                                                                          |
++------------------------------+---------------------------------------------------------------------------------------------------------------------+
+|  **Documentation**           |  .. image:: https://readthedocs.org/projects/nemo-cmd/badge/?version=latest                                         |
+|                              |      :target: https://nemo-cmd.readthedocs.io/en/latest/                                                            |
+|                              |      :alt: Documentation Status                                                                                     |
+|                              |  .. image:: https://github.com/SalishSeaCast/NEMO-Cmd/actions/workflows/sphinx-linkcheck.yaml/badge.svg             |
+|                              |      :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:sphinx-linkcheck                     |
+|                              |      :alt: Sphinx linkcheck                                                                                         |
++------------------------------+---------------------------------------------------------------------------------------------------------------------+
+|  **Package**                 |  .. image:: https://img.shields.io/github/v/release/SalishSeaCast/NEMO-Cmd?logo=github                              |
+|                              |      :target: https://github.com/SalishSeaCast/NEMO-Cmd/releases                                                    |
+|                              |      :alt: Releases                                                                                                 |
+|                              |  .. image:: https://img.shields.io/badge/Python-3.11%20%7C%203.12-blue?logo=python&label=Python&logoColor=gold      |
+|                              |      :target: https://docs.python.org/3.12/                                                                         |
+|                              |      :alt: Python Version                                                                                           |
+|                              |  .. image:: https://img.shields.io/github/issues/SalishSeaCast/NEMO-Cmd?logo=github                                 |
+|                              |      :target: https://github.com/SalishSeaCast/NEMO-Cmd/issues                                                      |
+|                              |      :alt: Issue Tracker                                                                                            |
++------------------------------+---------------------------------------------------------------------------------------------------------------------+
+|  **Meta**                    |  .. image:: https://img.shields.io/badge/license-Apache%202-cb2533.svg                                              |
+|                              |      :target: https://www.apache.org/licenses/LICENSE-2.0                                                           |
+|                              |      :alt: Licensed under the Apache License, Version 2.0                                                           |
+|                              |  .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github                                 |
+|                              |      :target: https://github.com/SalishSeaCast/NEMO-Cmd                                                             |
+|                              |      :alt: Git on GitHub                                                                                            |
+|                              |  .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white            |
+|                              |      :target: https://pre-commit.com                                                                                |
+|                              |      :alt: pre-commit                                                                                               |
+|                              |  .. image:: https://img.shields.io/badge/code%20style-black-000000.svg                                              |
+|                              |      :target: https://black.readthedocs.io/en/stable/                                                               |
+|                              |      :alt: The uncompromising Python code formatter                                                                 |
+|                              |  .. image:: https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg                                              |
+|                              |      :target: https://github.com/pypa/hatch                                                                         |
+|                              |      :alt: Hatch project                                                                                            |
++------------------------------+---------------------------------------------------------------------------------------------------------------------+
 
 The NEMO command processor, ``nemo``, is a command line tool for doing various operations
 associated with running the `NEMO`_ ocean model.

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ NEMO Command Processor
 |                              |  .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white            |
 |                              |      :target: https://pre-commit.com                                                                                |
 |                              |      :alt: pre-commit                                                                                               |
++                              +---------------------------------------------------------------------------------------------------------------------+
 |                              |  .. image:: https://img.shields.io/badge/code%20style-black-000000.svg                                              |
 |                              |      :target: https://black.readthedocs.io/en/stable/                                                               |
 |                              |      :alt: The uncompromising Python code formatter                                                                 |

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -22,42 +22,50 @@
 :kbd:`NEMO-Cmd` Package Development
 ***********************************
 
-.. image:: https://img.shields.io/badge/license-Apache%202-cb2533.svg
-    :target: https://www.apache.org/licenses/LICENSE-2.0
-    :alt: Licensed under the Apache License, Version 2.0
-.. image:: https://img.shields.io/badge/Python-3.11%20%7C%203.12-blue?logo=python&label=Python&logoColor=gold
-    :target: https://docs.python.org/3.11/
-    :alt: Python Version
-.. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github
-    :target: https://github.com/SalishSeaCast/NEMO-Cmd
-    :alt: Git on GitHub
-.. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
-    :target: https://github.com/pre-commit/pre-commit
-    :alt: pre-commit
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://black.readthedocs.io/en/stable/
-    :alt: The uncompromising Python code formatter
-.. image:: https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg
-    :alt: Hatch project
-    :target: https://github.com/pypa/hatch
-.. image:: https://readthedocs.org/projects/nemo-cmd/badge/?version=latest
-    :target: https://nemo-cmd.readthedocs.io/en/latest/
-    :alt: Documentation Status
-.. image:: https://github.com/SalishSeaCast/NEMO-Cmd/workflows/sphinx-linkcheck/badge.svg
-    :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:sphinx-linkcheck
-    :alt: Sphinx linkcheck
-.. image:: https://github.com/SalishSeaCast/NEMO-Cmd/workflows/pytest-with-coverage/badge.svg
-    :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:pytest-with-coverage
-    :alt: Pytest with Coverage Status
-.. image:: https://codecov.io/gh/SalishSeaCast/NEMO-Cmd/branch/main/graph/badge.svg
-    :target: https://app.codecov.io/gh/SalishSeaCast/NEMO-Cmd
-    :alt: Codecov Testing Coverage Report
-.. image:: https://github.com/SalishSeaCast/NEMO-Cmd/workflows/CodeQL/badge.svg
-    :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:CodeQL
-    :alt: CodeQL analysis
-.. image:: https://img.shields.io/github/issues/SalishSeaCast/NEMO-Cmd?logo=github
-    :target: https://github.com/SalishSeaCast/NEMO-Cmd/issues
-    :alt: Issue Tracker
++------------------------------+---------------------------------------------------------------------------------------------------------------------+
+|  **Continuous Integration**  |  .. image:: https://github.com/SalishSeaCast/NEMO-Cmd/actions/workflows/pytest-with-coverage.yaml/badge.svg         |
+|                              |       :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:pytest-with-coverage                |
+|                              |       :alt: Pytest with Coverage Status                                                                             |
+|                              |  .. image:: https://codecov.io/gh/SalishSeaCast/NEMO-Cmd/branch/main/graph/badge.svg                                |
+|                              |       :target: https://app.codecov.io/gh/SalishSeaCast/NEMO-Cmd                                                     |
+|                              |       :alt: Codecov Testing Coverage Report                                                                         |
+|                              |  .. image:: https://github.com/SalishSeaCast/NEMO-Cmd/actions/workflows/codeql-analysis.yaml/badge.svg              |
+|                              |      :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:CodeQL                               |
+|                              |      :alt: CodeQL analysis                                                                                          |
++------------------------------+---------------------------------------------------------------------------------------------------------------------+
+|  **Documentation**           |  .. image:: https://readthedocs.org/projects/nemo-cmd/badge/?version=latest                                         |
+|                              |      :target: https://nemo-cmd.readthedocs.io/en/latest/                                                            |
+|                              |      :alt: Documentation Status                                                                                     |
+|                              |  .. image:: https://github.com/SalishSeaCast/NEMO-Cmd/actions/workflows/sphinx-linkcheck.yaml/badge.svg             |
+|                              |      :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:sphinx-linkcheck                     |
+|                              |      :alt: Sphinx linkcheck                                                                                         |
++------------------------------+---------------------------------------------------------------------------------------------------------------------+
+|  **Package**                 |  .. image:: https://img.shields.io/github/v/release/SalishSeaCast/NEMO-Cmd?logo=github                              |
+|                              |      :target: https://github.com/SalishSeaCast/NEMO-Cmd/releases                                                    |
+|                              |      :alt: Releases                                                                                                 |
+|                              |  .. image:: https://img.shields.io/badge/Python-3.11%20%7C%203.12-blue?logo=python&label=Python&logoColor=gold      |
+|                              |      :target: https://docs.python.org/3.12/                                                                         |
+|                              |      :alt: Python Version                                                                                           |
+|                              |  .. image:: https://img.shields.io/github/issues/SalishSeaCast/NEMO-Cmd?logo=github                                 |
+|                              |      :target: https://github.com/SalishSeaCast/NEMO-Cmd/issues                                                      |
+|                              |      :alt: Issue Tracker                                                                                            |
++------------------------------+---------------------------------------------------------------------------------------------------------------------+
+|  **Meta**                    |  .. image:: https://img.shields.io/badge/license-Apache%202-cb2533.svg                                              |
+|                              |      :target: https://www.apache.org/licenses/LICENSE-2.0                                                           |
+|                              |      :alt: Licensed under the Apache License, Version 2.0                                                           |
+|                              |  .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github                                 |
+|                              |      :target: https://github.com/SalishSeaCast/NEMO-Cmd                                                             |
+|                              |      :alt: Git on GitHub                                                                                            |
+|                              |  .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white            |
+|                              |      :target: https://pre-commit.com                                                                                |
+|                              |      :alt: pre-commit                                                                                               |
+|                              |  .. image:: https://img.shields.io/badge/code%20style-black-000000.svg                                              |
+|                              |      :target: https://black.readthedocs.io/en/stable/                                                               |
+|                              |      :alt: The uncompromising Python code formatter                                                                 |
+|                              |  .. image:: https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg                                              |
+|                              |      :target: https://github.com/pypa/hatch                                                                         |
+|                              |      :alt: Hatch project                                                                                            |
++------------------------------+---------------------------------------------------------------------------------------------------------------------+
 
 
 .. _NEMO-CmdPythonVersions:
@@ -139,7 +147,7 @@ Coding Style
 ============
 
 .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
-    :target: https://github.com/pre-commit/pre-commit
+    :target: https://pre-commit.com
     :alt: pre-commit
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://black.readthedocs.io/en/stable/
@@ -261,7 +269,7 @@ Whenever you push changes to the :kbd:`NEMO-Cmd` repository on GitHub the docume
 Link Checking the Documentation
 -------------------------------
 
-.. image:: https://github.com/SalishSeaCast/NEMO-Cmd/workflows/sphinx-linkcheck/badge.svg
+.. image:: https://github.com/SalishSeaCast/NEMO-Cmd/actions/workflows/sphinx-linkcheck.yaml/badge.svg
     :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:sphinx-linkcheck
     :alt: Sphinx linkcheck
 
@@ -466,7 +474,7 @@ to produce an HTML report that you can view in your browser by opening :file:`NE
 Continuous Integration
 ----------------------
 
-.. image:: https://github.com/SalishSeaCast/NEMO-Cmd/workflows/pytest-with-coverage/badge.svg
+.. image:: https://github.com/SalishSeaCast/NEMO-Cmd/actions/workflows/pytest-with-coverage.yaml/badge.svg
     :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:pytest-with-coverage
     :alt: Pytest with Coverage Status
 .. image:: https://app.codecov.io/gh/SalishSeaCast/NEMO-Cmd/branch/main/graph/badge.svg
@@ -539,6 +547,13 @@ Please see the LICENSE file for details of the license.
 
 Release Process
 ===============
+
+.. image:: https://img.shields.io/github/v/release/SalishSeaCast/NEMO-Cmd?logo=github
+    :target: https://github.com/SalishSeaCast/NEMO-Cmd/releases
+    :alt: Releases
+.. image:: https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg
+    :target: https://github.com/pypa/hatch
+    :alt: Hatch project
 
 Releases are done at Doug's discretion when significant pieces of development work have been
 completed.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -59,6 +59,7 @@
 |                              |  .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white            |
 |                              |      :target: https://pre-commit.com                                                                                |
 |                              |      :alt: pre-commit                                                                                               |
++                              +---------------------------------------------------------------------------------------------------------------------+
 |                              |  .. image:: https://img.shields.io/badge/code%20style-black-000000.svg                                              |
 |                              |      :target: https://black.readthedocs.io/en/stable/                                                               |
 |                              |      :alt: The uncompromising Python code formatter                                                                 |


### PR DESCRIPTION
Reformatted the project badges in `README.rst` and `pkg_development.rst` into a table to improve readability and clarity. Badges are now grouped by "Continuous Integration", "Documentation", "Package" and "Meta" to provide a better overview of the project status, and its development tools and processes.