### PR TITLE
Exclude version string from coverage

### DIFF
--- a/nemo_cmd/__about__.py
+++ b/nemo_cmd/__about__.py
@@ -1,1 +1,19 @@
-__version__ = "24.2.dev0"
+# Copyright 2013 – present by the SalishSeaCast contributors
+# and The University of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+__version__ = "24.2.dev0"  # pragma: no cover


### PR DESCRIPTION
Added a pragma directive to the version string to exclude it from test coverage metrics. This ensures that changes to the version number do not affect code coverage reports.