### PR TITLE
Update URLs for AGRIF and ReadTheDocs links

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -199,7 +199,7 @@ v19.1 (2019-08-26)
 * Add support for the use of `AGRIF`_ (Adaptive Grid Refinement in Fortran)
   in NEMO-3.6 runs.
 
-.. _AGRIF: https://forge.ipsl.fr/nemo/wiki/Users/ModelInterfacing/AGRIF
+.. _AGRIF: https://agrif.imag.fr/index.html
 
 * Expand shell and user variables in namelist file paths.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -33,7 +33,7 @@
 |                            |      :target: https://github.com/SalishSeaCast/NEMO-Cmd/actions?query=workflow:CodeQL                                                                                                            |
 |                            |      :alt: CodeQL analysis                                                                                                                                                                       |
 +----------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **Documentation**          | .. image:: https://readthedocs.org/projects/nemo-cmd/badge/?version=latest                                                                                                                       |
+| **Documentation**          | .. image:: https://app.readthedocs.org/projects/nemo-cmd/badge/?version=latest                                                                                                                   |
 |                            |     :target: https://nemo-cmd.readthedocs.io/en/latest/                                                                                                                                          |
 |                            |     :alt: Documentation Status                                                                                                                                                                   |
 |                            | .. image:: https://github.com/SalishSeaCast/NEMO-Cmd/actions/workflows/sphinx-linkcheck.yaml/badge.svg                                                                                           |
@@ -182,7 +182,7 @@ and run :command:`pre-commit install`:
 Building the Documentation
 ==========================
 
-.. image:: https://readthedocs.org/projects/nemo-cmd/badge/?version=latest
+.. image:: https://app.readthedocs.org/projects/nemo-cmd/badge/?version=latest
     :target: https://nemo-cmd.readthedocs.io/en/latest/
     :alt: Documentation Status
 
@@ -208,7 +208,7 @@ follow the instructions in the :ref:`NEMO-CmdDevelopmentEnvironment` section abo
 In the development environment you can build the docs locally instead of having to push commits to GitHub to trigger a `build on readthedocs.org`_ and wait for it to complete.
 Below are instructions that explain how to:
 
-.. _build on readthedocs.org: https://readthedocs.org/projects/nemo-cmd/builds/
+.. _build on readthedocs.org: https://app.readthedocs.org/projects/nemo-cmd/builds/
 
 * build the docs with your changes,
   and preview them in Firefox


### PR DESCRIPTION
Replaced outdated URLs found by sphinx-linkcheck with updated ones for AGRIF and ReadTheDocs in two documentation files. Ensures links point to the correct locations and improves reliability for users accessing these resources.